### PR TITLE
Included SentItems as Folder with EmailMessageSchema

### DIFF
--- a/OutlookTools/OutlookTools/OutlookInputToolEngine.cs
+++ b/OutlookTools/OutlookTools/OutlookInputToolEngine.cs
@@ -155,6 +155,10 @@ namespace OutlookTools
                     {
                         propertyDefinitionBase[i] = (PropertyDefinitionBase)typeof(EmailMessageSchema).GetField(xmlConfig.Fields[i].Name).GetValue(null);
                     }
+                    else if ((WellKnownFolderName)xmlConfig.Folder == WellKnownFolderName.SentItems && typeof(EmailMessageSchema).GetField(xmlConfig.Fields[i].Name) != null)
+                    {
+                        propertyDefinitionBase[i] = (PropertyDefinitionBase)typeof(EmailMessageSchema).GetField(xmlConfig.Fields[i].Name).GetValue(null);
+                    }
                     else if ((WellKnownFolderName)xmlConfig.Folder == WellKnownFolderName.Tasks && typeof(TaskSchema).GetField(xmlConfig.Fields[i].Name) != null)
                     {
                         propertyDefinitionBase[i] = (PropertyDefinitionBase)typeof(TaskSchema).GetField(xmlConfig.Fields[i].Name).GetValue(null);

--- a/OutlookTools/OutlookTools/OutlookInputToolGui.cs
+++ b/OutlookTools/OutlookTools/OutlookInputToolGui.cs
@@ -341,6 +341,12 @@ namespace OutlookTools
 
                     clbFields.DataSource = new BindingSource(fields, null);
                     break;
+                case "8":
+                    fields = Member<EmailMessageSchema>.ToList((ExchangeVersion)cboExchangeVersion.SelectedValue);
+                    fields.Sort((x,y) => x.Value.CompareTo(y.Value));
+
+                    clbFields.DataSource = new BindingSource(fields,null);
+                    break;
                 case "9":
                     fields = Member<TaskSchema>.ToList((ExchangeVersion)cboExchangeVersion.SelectedValue);
                     fields.Sort((x, y) => x.Value.CompareTo(y.Value));


### PR DESCRIPTION
This allows you to select all the email message fields for the default "Sent Items" folder.